### PR TITLE
Selective CloudFront Invalidations

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -20,13 +20,6 @@ class Controller {
             1
         );
 
-        add_action(
-            'wp2static_post_deploy_trigger',
-            [ $this, 'post_deploy_trigger' ],
-            15,
-            1
-        );
-
         if ( defined( 'WP_CLI' ) ) {
             \WP_CLI::add_command(
                 'wp2static s3',
@@ -224,12 +217,6 @@ class Controller {
 
         $s3_deployer = new Deployer();
         $s3_deployer->upload_files( $processed_site_path );
-    }
-
-    public static function post_deploy_trigger() : void {
-        if ( Controller::getValue( 'cfInvalidateAllFiles' ) ) {
-            \WP2StaticS3\Deployer::cloudfront_invalidate_all_items();
-        }
     }
 
     public static function activate_for_single_site() : void {

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -175,6 +175,16 @@ class Controller {
         );
 
         $wpdb->query( $query );
+
+        $query = $wpdb->prepare(
+            $query_string,
+            's3CacheControl',
+            'public, max-age=900',
+            'Cache-Control header value',
+            ''
+        );
+
+        $wpdb->query( $query );
     }
 
     /**
@@ -392,6 +402,12 @@ class Controller {
             $table_name,
             [ 'value' => sanitize_text_field( $_POST['s3RemotePath'] ) ],
             [ 'name' => 's3RemotePath' ]
+        );
+
+        $wpdb->update(
+            $table_name,
+            [ 'value' => sanitize_text_field( $_POST['s3CacheControl'] ) ],
+            [ 'name' => 's3CacheControl' ]
         );
 
         wp_safe_redirect( admin_url( 'admin.php?page=wp2static-s3' ) );

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -22,7 +22,7 @@ class Controller {
 
         add_action(
             'wp2static_post_deploy_trigger',
-            [ 'WP2StaticS3\Deployer', 'cloudfront_invalidate_all_items' ],
+            [ $this, 'post_deploy_trigger' ],
             15,
             1
         );
@@ -224,6 +224,12 @@ class Controller {
 
         $s3_deployer = new Deployer();
         $s3_deployer->upload_files( $processed_site_path );
+    }
+
+    public static function post_deploy_trigger() : void {
+        if ( Controller::getValue( 'cfInvalidateAllFiles' ) ) {
+            \WP2StaticS3\Deployer::cloudfront_invalidate_all_items();
+        }
     }
 
     public static function activate_for_single_site() : void {

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -178,6 +178,16 @@ class Controller {
         );
 
         $wpdb->query( $query );
+
+        $query = $wpdb->prepare(
+            $query_string,
+            'cfMaxPathsToInvalidate',
+            '',
+            'Maximum number of paths to invalidate before triggering a full invalidation',
+            ''
+        );
+
+        $wpdb->query( $query );
     }
 
     /**
@@ -401,6 +411,12 @@ class Controller {
             $table_name,
             [ 'value' => sanitize_text_field( $_POST['s3CacheControl'] ) ],
             [ 'name' => 's3CacheControl' ]
+        );
+
+        $wpdb->update(
+            $table_name,
+            [ 'value' => sanitize_text_field( $_POST['cfMaxPathsToInvalidate'] ) ],
+            [ 'name' => 'cfMaxPathsToInvalidate' ]
         );
 
         wp_safe_redirect( admin_url( 'admin.php?page=wp2static-s3' ) );

--- a/src/Deployer.php
+++ b/src/Deployer.php
@@ -131,15 +131,15 @@ class Deployer {
                  - an IAM role.
         */
         if (
-            Controller::getValue( 's3AccessKeyID' ) &&
-            Controller::getValue( 's3SecretAccessKey' )
+            Controller::getValue( 'cfAccessKeyID' ) &&
+            Controller::getValue( 'cfSecretAccessKey' )
         ) {
 
             $credentials = new \Aws\Credentials\Credentials(
-                Controller::getValue( 's3AccessKeyID' ),
+                Controller::getValue( 'cfAccessKeyID' ),
                 \WP2Static\CoreOptions::encrypt_decrypt(
                     'decrypt',
-                    Controller::getValue( 's3SecretAccessKey' )
+                    Controller::getValue( 'cfSecretAccessKey' )
                 )
             );
         }

--- a/src/Deployer.php
+++ b/src/Deployer.php
@@ -92,7 +92,7 @@ class Deployer {
         }
     }
 
-    public function s3_client() : \Aws\S3\S3Client {
+    public static function s3_client() : \Aws\S3\S3Client {
         $client_options = [
             'version' => 'latest',
             'region' => Controller::getValue( 's3Region' ),
@@ -124,7 +124,7 @@ class Deployer {
         return new \Aws\S3\S3Client( $client_options );
     }
 
-    public function cloudfront_client() : \Aws\CloudFront\CloudFrontClient {
+    public static function cloudfront_client() : \Aws\CloudFront\CloudFrontClient {
         /*
             If no credentials option, SDK attempts to load credentials from
             your environment in the following order:
@@ -191,7 +191,7 @@ class Deployer {
         );
     }
 
-    public function cloudfront_invalidate_all_items() : void {
+    public static function cloudfront_invalidate_all_items() : void {
         if ( ! Controller::getValue( 'cfDistributionID' ) ) {
             return;
         }

--- a/src/Deployer.php
+++ b/src/Deployer.php
@@ -174,7 +174,7 @@ class Deployer {
     }
 
     public static function create_invalidation( string $distribution_id, array $items,
-                                         int $quantity ) : string {
+                                                int $quantity ) : string {
         $client = self::cloudfront_client();
 
         return $client->createInvalidation(

--- a/views/s3-page.php
+++ b/views/s3-page.php
@@ -111,6 +111,22 @@
             </td>
         </tr>
 
+        <tr>
+            <td style="width:50%;">
+                <label
+                    for="<?php echo $view['options']['s3CacheControl']->name; ?>"
+                ><?php echo $view['options']['s3CacheControl']->label; ?></label>
+            </td>
+            <td>
+                <input
+                    id="<?php echo $view['options']['s3CacheControl']->name; ?>"
+                    name="<?php echo $view['options']['s3CacheControl']->name; ?>"
+                    type="text"
+                    value="<?php echo $view['options']['s3CacheControl']->value !== '' ? $view['options']['s3CacheControl']->value : ''; ?>"
+                />
+            </td>
+        </tr>
+
     </tbody>
 </table>
 

--- a/views/s3-page.php
+++ b/views/s3-page.php
@@ -217,6 +217,21 @@
             </td>
         </tr>
 
+        <tr>
+            <td style="width:50%;">
+                <label
+                    for="<?php echo $view['options']['cfMaxPathsToInvalidate']->name; ?>"
+                ><?php echo $view['options']['cfMaxPathsToInvalidate']->label; ?></label>
+            </td>
+            <td>
+                <input
+                    id="<?php echo $view['options']['cfMaxPathsToInvalidate']->name; ?>"
+                    name="<?php echo $view['options']['cfMaxPathsToInvalidate']->name; ?>"
+                    type="text"
+                    value="<?php echo $view['options']['cfMaxPathsToInvalidate']->value !== '' ? $view['options']['cfMaxPathsToInvalidate']->value : ''; ?>"
+                />
+            </td>
+        </tr>
 
     </tbody>
 </table>


### PR DESCRIPTION
Closes #14. If there are only a few files to change (<= cfMaxPathsToInvalidate), we create an invalidation for those paths. If there are more than that, we invalidate the entire distribution.

This branch builds on #16 and #18.