### PR TITLE
Rework options

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -73,7 +73,7 @@ class Controller {
         $table_name = $wpdb->prefix . 'wp2static_addon_s3_options';
 
         $query_string =
-            "INSERT INTO $table_name (name, value, label, description) VALUES (%s, %s, %s, %s);";
+            "INSERT IGNORE INTO $table_name (name, value, label, description) VALUES (%s, %s, %s, %s);";
 
         $query = $wpdb->prepare(
             $query_string,
@@ -268,7 +268,7 @@ class Controller {
 
         $sql = "CREATE TABLE $table_name (
             id mediumint(9) NOT NULL AUTO_INCREMENT,
-            name VARCHAR(255) NOT NULL,
+            name VARCHAR(255) NOT NULL UNIQUE,
             value VARCHAR(255) NOT NULL,
             label VARCHAR(255) NULL,
             description VARCHAR(255) NULL,

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -233,6 +233,8 @@ class Controller {
     }
 
     public static function renderS3Page() : void {
+        self::seedOptions();
+
         $view = [];
         $view['nonce_action'] = 'wp2static-s3-options';
         $view['uploads_path'] = \WP2Static\SiteInfo::getPath( 'uploads' );
@@ -280,9 +282,7 @@ class Controller {
 
         $options = self::getOptions();
 
-        if ( ! isset( $options['s3Bucket'] ) ) {
-            self::seedOptions();
-        }
+        self::seedOptions();
     }
 
     public static function deactivate_for_single_site() : void {


### PR DESCRIPTION
This makes the name column UNIQUE so that you can't have 2 rows with the same name and seeds all options whenever the plugin is activated or the options page is viewed. This way people updating their builds can install the new options easily. The seeding uses INSERT IGNORE, so existing options will be retained.

Closes #31.